### PR TITLE
Buggfix egzon

### DIFF
--- a/MandalorianBankomaten/Accounts/Account.cs
+++ b/MandalorianBankomaten/Accounts/Account.cs
@@ -1,5 +1,4 @@
 using MandalorianBankomaten.Menu;
-using System.Globalization;
 
 namespace MandalorianBankomaten.Accounts
 {

--- a/MandalorianBankomaten/Accounts/SavingAccount.cs
+++ b/MandalorianBankomaten/Accounts/SavingAccount.cs
@@ -30,10 +30,9 @@ namespace MandalorianBankomaten.Accounts
         public void ApplyInterest()
         {
             decimal totalInterest = Balance * _interestRate;
-            Balance += totalInterest;
+            //Balance += totalInterest;
             MenuUtility.CustomWriteLine(49, $"Räntesats: {_interestRate:P} , {CurrencyCode}");
             MenuUtility.CustomWriteLine(49, $"Årlig ränta: { CurrencyConverter.FormatAmount(totalInterest, CurrencyCode)}");
-            MenuUtility.CustomWriteLine(49, $"Saldo inklusive ränta: {CurrencyConverter.FormatAmount(Balance, CurrencyCode)}");
         }
         public override string ToString()
         {

--- a/MandalorianBankomaten/Bank.cs
+++ b/MandalorianBankomaten/Bank.cs
@@ -7,7 +7,6 @@ using MandalorianBankomaten.Users;
 using System;
 using System.Globalization;
 using System.Text;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace MandalorianBankomaten
 {
@@ -414,8 +413,8 @@ namespace MandalorianBankomaten
             }
 
             // Utför överföringen
-            CurrentUser.TransferMoneyBetweenAccounts(fromAccount, toAccount, amount);
-            CurrencyConverter.Converter(fromAccount.CurrencyCode, toAccount.CurrencyCode, amount);
+            decimal amountConverted = CurrencyConverter.Converter(fromAccount.CurrencyCode, toAccount.CurrencyCode, amount);
+            CurrentUser.TransferMoneyBetweenAccounts(fromAccount, toAccount, amount, amountConverted);
 
             // Log the transaction----------
             string transferInfo = $"Överföring: {CurrencyConverter.FormatAmount(amount, fromAccount.CurrencyCode)} från konto {fromAccount.AccountID} till konto {toAccount.AccountID}";

--- a/MandalorianBankomaten/CurrencyConverter.cs
+++ b/MandalorianBankomaten/CurrencyConverter.cs
@@ -1,6 +1,5 @@
-﻿using System.Globalization;
-using System.Collections.Generic;
-using MandalorianBankomaten.Menu;
+﻿using MandalorianBankomaten.Menu;
+using System.Globalization;
 
 namespace MandalorianBankomaten
 {
@@ -37,21 +36,20 @@ namespace MandalorianBankomaten
         //calculates the amount and rate
         public static decimal Converter(string fromCurrency, string toCurrency, decimal amount)
         {
-            
-            if (!CurrencyData.ContainsKey(fromCurrency) && !CurrencyData.ContainsKey(toCurrency))
-            {
-                MenuUtility.CustomWriteLine(49, "Ogiltig valuta kod");
-            }
+            // Om valutorna är samma, ingen konvertering behövs
             if (fromCurrency == toCurrency)
             {
-                //no conversion needed
                 return amount;
             }
 
+            // Hämta växelkurser
             decimal fromRate = CurrencyData[fromCurrency].Rate;
             decimal toRate = CurrencyData[toCurrency].Rate;
 
-            return amount * (toRate / fromRate);
+            // Beräkna det omvandlade beloppet
+            decimal convertedAmount = amount * (toRate / fromRate);
+
+            return convertedAmount; // Detta är beloppet i "toCurrency"
         }
 
         //method for both the converter and valdiation 

--- a/MandalorianBankomaten/Menu/MenuUtility.cs
+++ b/MandalorianBankomaten/Menu/MenuUtility.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Data;
-using System.Security.Cryptography.X509Certificates;
-
-namespace MandalorianBankomaten.Menu
+﻿namespace MandalorianBankomaten.Menu
 {
     public class MenuUtility
     {

--- a/MandalorianBankomaten/Users/User.cs
+++ b/MandalorianBankomaten/Users/User.cs
@@ -2,7 +2,6 @@ using MandalorianBankomaten.Accounts;
 using MandalorianBankomaten.Loans;
 using MandalorianBankomaten.Menu;
 using System.Globalization;
-using System.Security.Principal;
 
 namespace MandalorianBankomaten.Users
 {
@@ -101,7 +100,7 @@ namespace MandalorianBankomaten.Users
             Console.SetCursorPosition(49, 4);
             MenuUtility.CustomWriteLine(49, "Välj typ av konto du vill skapa:");
             MenuUtility.CustomWriteLine(49, "[1] Vanligt konto");
-            MenuUtility.CustomWriteLine(49, "[2] Sparkonto med 4% ränta");
+            MenuUtility.CustomWriteLine(49, "[2] Sparkonto med 5% ränta");
 
             int accountType;
             while (true)
@@ -263,7 +262,7 @@ namespace MandalorianBankomaten.Users
         }
         //between users
         //this
-        public void TransferMoneyBetweenAccounts(Account fromAccount, Account toAccount, decimal amount)
+        public void TransferMoneyBetweenAccounts(Account fromAccount, Account toAccount, decimal amount, decimal amountConverted)
         {
 
             if (fromAccount.Balance >= amount)
@@ -272,19 +271,13 @@ namespace MandalorianBankomaten.Users
                 MenuUtility.CustomWriteLine(49, $"Överföring från {fromAccount.AccountName} till {toAccount.AccountName} lyckades.");
 
                 //CurrencyConverter.Converter(fromAccount.CurrencyCode, toAccount.CurrencyCode, amount);
-                //fromAccount.Withdraw(amount);
-                //toAccount.Deposit(amount);
+                fromAccount.Withdraw(amount);
+                toAccount.Deposit(amountConverted);
             }
             else
             {
                 MenuUtility.CustomWriteLine(49, "Otillräckligt saldo för överföring.");
             }
-
-            decimal converterAmount = CurrencyConverter.Converter(fromAccount.CurrencyCode, toAccount.CurrencyCode, amount);
-
-            fromAccount.Withdraw(converterAmount - amount);
-            toAccount.Deposit(converterAmount + amount);
-
         }
 
         //this


### PR DESCRIPTION
Transfer between accounts did not work properly with currency conversion. The problem was that the amount transferred was converted and the sum of that conversion was applied to the Withdraw AND the Desposit method. The original amount was no longer present. If you wanted to transfer 5000 SEK to USD, you would end up with -500 SEK and + 500 USD when it should be -5000 SEK and + 500 USD.